### PR TITLE
Removed install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Superfish Menu for Expression Engine Control Panel
 
-This is an extension for Expression Engine which will convert its admin control panel menu into a Superfish menu with hoverIntent behaviour. I've never used EE before, so I'm not really sure if these files should be packaged in a more install-friendly way. Let me know in the issues area!
+This is an extension for Expression Engine which will convert its admin control panel menu into a Superfish menu with hoverIntent behaviour.
 
 ## Download
 


### PR DESCRIPTION
How you added the link to download the file is plenty sufficient. The folders are setup to be dropped in under un-changed circumstances and those who have custom add-on folder locations will know exactly where the folders go.
